### PR TITLE
fix: revert removal of templates from webhook

### DIFF
--- a/examples/operator/templates/mutating-webhook-configuration.yaml
+++ b/examples/operator/templates/mutating-webhook-configuration.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: {{ include "operator.fullname" . }}-mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator.fullname" . }}-serving-cert
   labels:

--- a/examples/operator/templates/validating-webhook-configuration.yaml
+++ b/examples/operator/templates/validating-webhook-configuration.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: {{ include "operator.fullname" . }}-validating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "operator.fullname" . }}-serving-cert
   labels:

--- a/pkg/processor/webhook/mutating.go
+++ b/pkg/processor/webhook/mutating.go
@@ -19,7 +19,7 @@ const (
 	mwhTempl = `apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: %[2]s
+  name: {{ include "%[1]s.fullname" . }}-%[2]s
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "%[1]s.fullname" . }}-%[3]s
   labels:

--- a/pkg/processor/webhook/validating.go
+++ b/pkg/processor/webhook/validating.go
@@ -19,7 +19,7 @@ const (
 	vwhTempl = `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: %[2]s
+  name: {{ include "%[1]s.fullname" . }}-%[2]s
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "%[1]s.fullname" . }}-%[3]s
   labels:


### PR DESCRIPTION
This reverts commit 229c089dba8c8de096bbbc2cdcd2600e57af7f39. Thanks to https://github.com/keptn/lifecycle-toolkit/pull/900 we do not need hard coded names for webhooks